### PR TITLE
EVP_PKEY_bits instead of EVP_PKEY_size, require >=openssl-1.1.1

### DIFF
--- a/configure
+++ b/configure
@@ -18244,12 +18244,12 @@ if test -n "$LIBCRYPTO_CFLAGS"; then
     pkg_cv_LIBCRYPTO_CFLAGS="$LIBCRYPTO_CFLAGS"
  elif test -n "$PKG_CONFIG"; then
     if test -n "$PKG_CONFIG" && \
-    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"openssl >= 0.9.7\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "openssl >= 0.9.7") 2>&5
+    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"openssl >= 1.1.1\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "openssl >= 1.1.1") 2>&5
   ac_status=$?
   printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
-  pkg_cv_LIBCRYPTO_CFLAGS=`$PKG_CONFIG --cflags "openssl >= 0.9.7" 2>/dev/null`
+  pkg_cv_LIBCRYPTO_CFLAGS=`$PKG_CONFIG --cflags "openssl >= 1.1.1" 2>/dev/null`
 		      test "x$?" != "x0" && pkg_failed=yes
 else
   pkg_failed=yes
@@ -18261,12 +18261,12 @@ if test -n "$LIBCRYPTO_LIBS"; then
     pkg_cv_LIBCRYPTO_LIBS="$LIBCRYPTO_LIBS"
  elif test -n "$PKG_CONFIG"; then
     if test -n "$PKG_CONFIG" && \
-    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"openssl >= 0.9.7\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "openssl >= 0.9.7") 2>&5
+    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"openssl >= 1.1.1\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "openssl >= 1.1.1") 2>&5
   ac_status=$?
   printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
-  pkg_cv_LIBCRYPTO_LIBS=`$PKG_CONFIG --libs "openssl >= 0.9.7" 2>/dev/null`
+  pkg_cv_LIBCRYPTO_LIBS=`$PKG_CONFIG --libs "openssl >= 1.1.1" 2>/dev/null`
 		      test "x$?" != "x0" && pkg_failed=yes
 else
   pkg_failed=yes
@@ -18287,9 +18287,9 @@ else
         _pkg_short_errors_supported=no
 fi
         if test $_pkg_short_errors_supported = yes; then
-	        LIBCRYPTO_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "openssl >= 0.9.7" 2>&1`
+	        LIBCRYPTO_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "openssl >= 1.1.1" 2>&1`
         else
-	        LIBCRYPTO_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "openssl >= 0.9.7" 2>&1`
+	        LIBCRYPTO_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "openssl >= 1.1.1" 2>&1`
         fi
 	# Put the nasty error message in config.log where it belongs
 	echo "$LIBCRYPTO_PKG_ERRORS" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -796,7 +796,7 @@ fi
 
 if test \( "$sslpath" = "auto" -o x"$sslpath" = x"yes" \) -a x"$PKG_CONFIG" != x""
 then
-	PKG_CHECK_MODULES([LIBCRYPTO], [openssl >= 0.9.7],
+	PKG_CHECK_MODULES([LIBCRYPTO], [openssl >= 1.1.1],
 	                  [openssl_found="yes"],
 	                  [openssl_found="no"
 	                   AC_MSG_WARN([pkg-config for openssl not found, trying manual search...])

--- a/libopendkim/dkim-test.c
+++ b/libopendkim/dkim-test.c
@@ -432,8 +432,6 @@ dkim_test_key(DKIM_LIB *lib, char *selector, char *domain,
 			return -1;
 		}
 
-		crypto->crypto_keysize = EVP_PKEY_size(crypto->crypto_pkey);
-
 		outkey = BIO_new(BIO_s_mem());
 		if (outkey == NULL)
 		{

--- a/libopendkim/dkim.c
+++ b/libopendkim/dkim.c
@@ -1266,7 +1266,7 @@ dkim_privkey_load(DKIM *dkim)
 	}
 
 	crypto->crypto_outlen = EVP_PKEY_size(crypto->crypto_pkey);
-	crypto->crypto_keysize = crypto->crypto_outlen * 8;
+	crypto->crypto_keysize = EVP_PKEY_bits(crypto->crypto_pkey);
 
 	crypto->crypto_out = DKIM_MALLOC(dkim, crypto->crypto_outlen);
 	if (crypto->crypto_out == NULL)
@@ -5847,7 +5847,7 @@ dkim_sig_process(DKIM *dkim, DKIM_SIGINFO *sig)
 
 			EVP_MD_CTX_free(md_ctx);
 
-			crypto->crypto_keysize = EVP_PKEY_size(crypto->crypto_pkey);
+			crypto->crypto_keysize = EVP_PKEY_bits(crypto->crypto_pkey);
 		}
 		else
 # endif /* HAVE_ED25519 */
@@ -5866,7 +5866,7 @@ dkim_sig_process(DKIM *dkim, DKIM_SIGINFO *sig)
 				return DKIM_STAT_OK;
 			}
 
-			crypto->crypto_keysize = EVP_PKEY_size(crypto->crypto_pkey);
+			crypto->crypto_keysize = EVP_PKEY_bits(crypto->crypto_pkey);
 
 			crypto->crypto_in = sig->sig_sig;
 			crypto->crypto_inlen = sig->sig_siglen;
@@ -5933,7 +5933,7 @@ dkim_sig_process(DKIM *dkim, DKIM_SIGINFO *sig)
 
 		dkim_sig_load_ssl_errors(dkim, sig, 0);
 
-		sig->sig_keybits = 8 * crypto->crypto_keysize;
+		sig->sig_keybits = crypto->crypto_keysize;
 
 		BIO_CLOBBER(key);
 		EVP_CLOBBER(crypto->crypto_pkey);


### PR DESCRIPTION
EVP_PKEY_size() is being used to get the key size in bytes, but it doesn't do that. It returns a suggested crypto buffer size.

To get the key size instead use EVP_PKEY_bits() which returns the key size in bits.

Also in configure.ac increase the minimum openssl version from 0.9.7 to 1.1.1.
